### PR TITLE
modify 公众号支付(JS API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 *.p12
 test
+.idea

--- a/lib/wxpay.js
+++ b/lib/wxpay.js
@@ -93,7 +93,7 @@ WXPay.mix('getBrandWCPayRequestParams', function(order, fn){
 			fn(null, reqparam);
 		} else {
 			if (!err) {
-				err = new Error(data.err_code_des);
+				err = new Error(data.err_code_des || data.return_msg);
 				err.res = data;
 			}
 			fn(err);

--- a/lib/wxpay.js
+++ b/lib/wxpay.js
@@ -81,15 +81,23 @@ WXPay.mix('getBrandWCPayRequestParams', function(order, fn){
 	order.trade_type = "JSAPI";
 	var _this = this;
 	this.createUnifiedOrder(order, function(err, data){
-		var reqparam = {
-			appId: _this.options.appid,
-			timeStamp: Math.floor(Date.now()/1000)+"",
-			nonceStr: data.nonce_str,
-			package: "prepay_id="+data.prepay_id,
-			signType: "MD5"
-		};
-		reqparam.paySign = _this.sign(reqparam);
-		fn(err, reqparam);
+		if (data.return_code === 'SUCCESS' && data.result_code === 'SUCCESS') {
+			var reqparam = {
+				appId: _this.options.appid,
+				timeStamp: Math.floor(Date.now() / 1000) + "",
+				nonceStr: data.nonce_str,
+				package: "prepay_id=" + data.prepay_id,
+				signType: "MD5"
+			};
+			reqparam.paySign = _this.sign(reqparam);
+			fn(null, reqparam);
+		} else {
+			if (!err) {
+				err = new Error(data.err_code_des);
+				err.res = data;
+			}
+			fn(err);
+		}
 	});
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weixin-pay",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "weixin payment",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
完善公众号支付(JS API)异常处理，增加对return_code和result_code的判断，如果return_code和result_code不全为'SUCCESS'则返回错误并且携带微信服务器返回的错误信息
