### PR TITLE
统一下单接口去掉证书依赖；

### DIFF
--- a/lib/wxpay.js
+++ b/lib/wxpay.js
@@ -66,11 +66,7 @@ WXPay.mix('createUnifiedOrder', function(opts, fn){
 	request({
 		url: "https://api.mch.weixin.qq.com/pay/unifiedorder",
 		method: 'POST',
-		body: util.buildXML(opts),
-		agentOptions: {
-			pfx: this.options.pfx,
-			passphrase: this.options.mch_id
-		}
+		body: util.buildXML(opts)
 	}, function(err, response, body){
 		util.parseXML(body, fn);
 	});


### PR DESCRIPTION
在没用到需要证书的接口时，用户可以不必部署证书。